### PR TITLE
Modernize, fix >32-bit encoding, handle short reads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Run Tests
 
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   tests:
@@ -9,12 +12,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ">=1.18"
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
 
       - name: Run tests
-        run: go test -v
+        run: go test -race -v ./...
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Zero dependency Go implementation of Kamailio BINRPC protocol, for invoking RPC 
 
 This library works with any Kamailio version.
 
-go-kamailio-binrpc requires at least Go 1.18.
+go-kamailio-binrpc requires at least Go 1.22.
 
 ## Usage
 

--- a/binrpc.go
+++ b/binrpc.go
@@ -5,11 +5,11 @@
 //
 // The BINRPC protocol is described in "src/modules/ctl/binrpc.h": https://github.com/kamailio/kamailio/blob/master/src/modules/ctl/binrpc.h
 //
-// Limits
+// # Limits
 //
 // The current implementation handles only int, string, and structs containing int or string values. Other types will return an error.
 //
-// Usage
+// # Usage
 //
 // High level functions:
 //
@@ -17,37 +17,36 @@
 //
 // - ReadPacket to read the response
 //
-//   package main
+//	package main
 //
-//   import (
-//   	"fmt"
-//   	"net"
+//	import (
+//		"fmt"
+//		"net"
 //
-//   	binrpc "github.com/florentchauveau/go-kamailio-binrpc/v3"
-//   )
+//		binrpc "github.com/florentchauveau/go-kamailio-binrpc/v3"
+//	)
 //
-//   func main() {
-//   	conn, err := net.Dial("tcp", "localhost:2049")
+//	func main() {
+//		conn, err := net.Dial("tcp", "localhost:2049")
 //
-//   	if err != nil {
-//   		panic(err)
-//   	}
+//		if err != nil {
+//			panic(err)
+//		}
 //
-//   	cookie, err := binrpc.WritePacket(conn, "tm.stats")
+//		cookie, err := binrpc.WritePacket(conn, "tm.stats")
 //
-//   	if err != nil {
-//   		panic(err)
-//   	}
+//		if err != nil {
+//			panic(err)
+//		}
 //
-//   	records, err := binrpc.ReadPacket(conn, cookie)
+//		records, err := binrpc.ReadPacket(conn, cookie)
 //
-//   	if err != nil {
-//   		panic(err)
-//   	}
+//		if err != nil {
+//			panic(err)
+//		}
 //
-//   	fmt.Printf("records = %v", records)
-//   }
-//
+//		fmt.Printf("records = %v", records)
+//	}
 package binrpc
 
 import (
@@ -56,7 +55,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 )
 

--- a/binrpc.go
+++ b/binrpc.go
@@ -556,12 +556,13 @@ func WritePacket[T ValidTypes](w io.Writer, values ...T) (uint32, error) {
 }
 
 // getMinBinarySizeOfInt returns the minimum size in bytes required to store an integer.
+// Negative values take 8 bytes (two's complement).
 func getMinBinarySizeOfInt(value int) uint8 {
-	n := uint32(value)
+	n := uint64(value)
 	size := uint8(0)
 
-	for size = 4; size > 0 && ((n & (0xff << 24)) == 0); size-- {
-		n <<= 8
+	for ; n > 0; n >>= 8 {
+		size++
 	}
 
 	return size

--- a/binrpc.go
+++ b/binrpc.go
@@ -298,10 +298,8 @@ func CreateRecord[T ValidTypes](v T) (*Record, error) {
 func ReadHeader(r io.Reader) (*Header, error) {
 	buf := make([]byte, 2)
 
-	if len, err := r.Read(buf); err != nil {
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return nil, fmt.Errorf("cannot read header: %w", err)
-	} else if len != 2 {
-		return nil, fmt.Errorf("cannot read header: read=%d/%d", len, 2)
 	}
 
 	if magic := buf[0] >> 4; magic != BinRPCMagic {
@@ -317,10 +315,8 @@ func ReadHeader(r io.Reader) (*Header, error) {
 
 	buf = make([]byte, sizeOfLength)
 
-	if len, err := r.Read(buf); err != nil {
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return nil, fmt.Errorf("cannot read total length: %w", err)
-	} else if len != int(sizeOfLength) {
-		return nil, fmt.Errorf("cannot read total length, read=%d/%d", len, sizeOfLength)
 	}
 
 	header := Header{}
@@ -331,10 +327,8 @@ func ReadHeader(r io.Reader) (*Header, error) {
 
 	cookieBytes := make([]byte, sizeOfCookie)
 
-	if len, err := r.Read(cookieBytes); err != nil {
+	if _, err := io.ReadFull(r, cookieBytes); err != nil {
 		return nil, fmt.Errorf("cannot read cookie: %w", err)
-	} else if len != int(sizeOfCookie) {
-		return nil, fmt.Errorf("cannot read cookie, read=%d/%d", len, sizeOfCookie)
 	}
 
 	for _, b := range cookieBytes {
@@ -350,10 +344,8 @@ func ReadRecord(r io.Reader) (*Record, error) {
 
 	buf := make([]byte, 1)
 
-	if len, err := r.Read(buf); err != nil {
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return nil, fmt.Errorf("cannot read record header: %w", err)
-	} else if len != 1 {
-		return nil, fmt.Errorf("cannot read record header: read=%d/1", len)
 	}
 
 	flag := buf[0] >> 7
@@ -370,10 +362,8 @@ func ReadRecord(r io.Reader) (*Record, error) {
 	if flag == 1 {
 		buf = make([]byte, size)
 
-		if len, err := r.Read(buf); err != nil {
+		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, fmt.Errorf("cannot read record size: %w", err)
-		} else if len != size {
-			return nil, fmt.Errorf("cannot read record size: read=%d/%d", len, size)
 		}
 
 		size = 0
@@ -389,10 +379,8 @@ func ReadRecord(r io.Reader) (*Record, error) {
 	} else {
 		buf = make([]byte, size)
 
-		if len, err := r.Read(buf); err != nil {
+		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, fmt.Errorf("cannot read record value: %w", err)
-		} else if len != size {
-			return nil, fmt.Errorf("cannot read record value: read=%d/%d", len, size)
 		}
 	}
 

--- a/binrpc_test.go
+++ b/binrpc_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net"
 	"testing"
+	"testing/iotest"
 )
 
 func TestReadHeader(t *testing.T) {
@@ -548,5 +549,55 @@ func TestWritePacketReadPacketRoundTrip(t *testing.T) {
 
 	if i != 67108864000 {
 		t.Errorf("expected 67108864000, got %d", i)
+	}
+}
+
+// TestReadFragmented verifies that headers, records, and whole packets
+// arriving in arbitrarily small chunks (as TCP allows) are read
+// correctly. Short reads used to be treated as errors.
+func TestReadFragmented(t *testing.T) {
+	headerData := []byte{0xa1, 0x03, 0x0b, 0x6f, 0x8d, 0xa2, 0x97}
+	header, err := ReadHeader(iotest.OneByteReader(bytes.NewReader(headerData)))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if header.PayloadLength != 11 || header.Cookie != 0x6f8da297 {
+		t.Errorf("unexpected header: %+v", header)
+	}
+
+	recordData, _ := hex.DecodeString("9109746d2e737461747300")
+	record, err := ReadRecord(iotest.OneByteReader(bytes.NewReader(recordData)))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s, _ := record.String(); s != "tm.stats" {
+		t.Errorf(`expected "tm.stats", got "%s"`, s)
+	}
+
+	packetData, _ := hex.DecodeString("a1322a9883af2001f49125636f6d6d616e6420636f72652e6563686f20626f6e6a6f757273206e6f7420666f756e6400")
+	records, err := ReadPacket(iotest.OneByteReader(bytes.NewReader(packetData)), 0x9883af)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(records) != 2 {
+		t.Errorf("expected 2 records, got %d", len(records))
+	}
+}
+
+// TestReadRecordTruncated verifies that a truncated record returns an
+// error instead of blocking or succeeding.
+func TestReadRecordTruncated(t *testing.T) {
+	data, _ := hex.DecodeString("9109746d2e737461747300")
+
+	for size := 1; size < len(data); size++ {
+		if _, err := ReadRecord(bytes.NewReader(data[:size])); err == nil {
+			t.Errorf("expected an error for a record truncated at %d bytes", size)
+		}
 	}
 }

--- a/binrpc_test.go
+++ b/binrpc_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"net"
 	"testing"
 )
@@ -419,5 +420,133 @@ func ExampleWritePacket_structResponseScan() {
 			item.Key,
 			value,
 		)
+	}
+}
+
+// TestEncodeIntRoundTrip verifies that ints of every binary size survive
+// an encode/decode round trip. Values larger than 32 bits used to be
+// silently truncated when encoding.
+func TestEncodeIntRoundTrip(t *testing.T) {
+	values := []int{
+		0,
+		1,
+		142,
+		255,
+		256,
+		65536,
+		8388605,
+		0xFFFFFFFF,
+		0x100000000,   // 5 bytes, was truncated to 0
+		67108864000,   // 64 MiB as a fixed-point double, was truncated
+		math.MaxInt64, // 8 bytes, forces the long size form
+		-1,
+		-1500,
+	}
+
+	for _, value := range values {
+		record, err := CreateRecord(value)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+
+		if err = record.Encode(&buf); err != nil {
+			t.Fatalf("value %d: %s", value, err)
+		}
+
+		decoded, err := ReadRecord(&buf)
+
+		if err != nil {
+			t.Fatalf("value %d: %s", value, err)
+		}
+
+		i, err := decoded.Int()
+
+		if err != nil {
+			t.Fatalf("value %d: %s", value, err)
+		}
+
+		if i != value {
+			t.Errorf("expected %d, got %d", value, i)
+		}
+	}
+}
+
+// TestEncodeDoubleRoundTrip verifies that doubles (fixed-point with
+// 3 decimals) survive an encode/decode round trip, including values
+// whose fixed-point representation exceeds 32 bits.
+func TestEncodeDoubleRoundTrip(t *testing.T) {
+	values := []float64{
+		0,
+		1.5,
+		2590984.25,
+		4294967.295, // largest fixed-point value that fits in 32 bits
+		4294967.296, // smallest that does not
+		67108864,    // 64 MiB, as returned by core.shmmem
+		-1.5,
+	}
+
+	for _, value := range values {
+		record, err := CreateRecord(value)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+
+		if err = record.Encode(&buf); err != nil {
+			t.Fatalf("value %f: %s", value, err)
+		}
+
+		decoded, err := ReadRecord(&buf)
+
+		if err != nil {
+			t.Fatalf("value %f: %s", value, err)
+		}
+
+		d, err := decoded.Double()
+
+		if err != nil {
+			t.Fatalf("value %f: %s", value, err)
+		}
+
+		if d != value {
+			t.Errorf("expected %f, got %f", value, d)
+		}
+	}
+}
+
+// TestWritePacketReadPacketRoundTrip verifies a full packet round trip
+// with a value larger than 32 bits.
+func TestWritePacketReadPacketRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+
+	cookie, err := WritePacket(&buf, 67108864000)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := ReadPacket(&buf, cookie)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	i, err := records[0].Int()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 67108864000 {
+		t.Errorf("expected 67108864000, got %d", i)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/florentchauveau/go-kamailio-binrpc/v3
 
-go 1.18
+go 1.22


### PR DESCRIPTION
Three commits:

## Modernize
- require go1.22, use `math/rand/v2` for cookie generation (the old global `math/rand` source made cookie sequences deterministic across process restarts with a go1.18 directive)
- CI runs on pull requests with `-race`, vet, and gofmt checks; Dependabot added
- gofmt with current Go, removed empty go.sum

## Fix encoding of values larger than 32 bits
`getMinBinarySizeOfInt` cast the value to `uint32`, so ints and doubles whose binary representation exceeded 4 bytes were silently truncated (mod 2^32) by `Encode`/`WritePacket`. The read path already handled any size. Negative values now round-trip correctly as well (they previously decoded as large positive values). Found while writing tests for kamailio_exporter v2: a 64 MiB `core.shmmem` value encoded as a double came back as 2684354.56.

## Handle short reads with io.ReadFull
`ReadHeader`/`ReadRecord` used bare `Read` calls and treated partial reads as errors — a packet arriving in several TCP segments failed with `cannot read header: read=1/2`. `io.ReadFull` retries until the buffer is full.

Test coverage: 12 → 17 tests; the new round-trip and fragmentation tests fail against the previous code and pass with the fixes. Suggest tagging v3.3.0 (backward compatible: wire format for previously-working values is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)